### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -25,7 +25,7 @@ jobs:
         run: ./update.sh ic-http-lb
 
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
         with:
           token: ${{ steps.app-token.outputs.token }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/create-github-app-token@v2` -> `actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2`
  - Version: v2.2.2 | Latest: v3.0.0 | Release age: 27d
  - Commit: https://github.com/actions/create-github-app-token/commit/fee1f7d63c2ff003460e3d139729b119787bc349

- `peter-evans/enable-pull-request-automerge@v3` -> `peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3`
  - Version: v3 | Latest: v3.0.0 | Release age: 1114d
  - Commit: https://github.com/peter-evans/enable-pull-request-automerge/commit/a660677d5469627102a1c1e11409dd063606628d


### Files modified

- `.github/workflows/update.yml`